### PR TITLE
Feature/support for comand line arguments

### DIFF
--- a/python_program/Readme.md
+++ b/python_program/Readme.md
@@ -9,6 +9,7 @@ Note: the script is only tested with GPX-files exported form SchweizMobil and fo
 should work with arbitrary GPX-files.
 
 ## Settings: Supported command-line args
+
 All arguments are optional (or have a default value). However, the arguments allow choosing various settings.
 
 Name | arguments | Description
@@ -18,6 +19,7 @@ Name | arguments | Description
 `--velocity` | `Float` | Speed in km/h on which the calculation is based, default 3.75 km/h.
 `--map-scaling` | `Integer` | Scaling of the created map (e.g. 10000 for scaling of 1:10'000), if not specified the scaling will be automatically chosen.
 `--open-images` | None | If this flag is set, the created images will be shown (i.g. the map and elevation plot will be opened after its creation). For this feature a desktop environment is needed.
+`--departure-time` | ISO-timestamp | Departure date in ISO-format, i.g. 2011-11-04T00:05:23. Default 2021-08-16T09:00:00.
 
 ## About swisstopo Services
 

--- a/python_program/Readme.md
+++ b/python_program/Readme.md
@@ -1,10 +1,23 @@
-# How to run it?
+# How to run the script?
 
 Make sure you have installed python 3 and all requirements listed in the requirements.txt file. Now you can
-run ```main.py``` to launch the script. The produced files get saved in the ./output directory.
+run ```main.py``` to launch the script. The produced files get saved in the ```./output``` directory. In
+the ```main.py``` you can specify the ```DEPARTURE_TIME```, ```GPX_FILE_PATH```, and ```VELOCITY``` as command-line
+arguments, see table bellow.
 
-In the ```main.py``` you can specify the ```DEPARTURE_TIME```, ```GPX_FILE_PATH```, and ```VELOCITY```. Note: the script
-is only tested with GPX-files exported form SchweizMobil, but it should work with arbitrary GPX-files.
+Note: the script is only tested with GPX-files exported form SchweizMobil and form the official swisstopo app, but it
+should work with arbitrary GPX-files.
+
+## Settings: Supported command-line args
+All arguments are optional (or have a default value). However, the arguments allow choosing various settings.
+
+Name | arguments | Description
+--- | --- | ---
+|  |
+`--gpx-file-name` | `String` | Name and path to the GPX file, if not specified ```./GPX/Default_Route.gpx```  will be used as default value.
+`--velocity` | `Float` | Speed in km/h on which the calculation is based, default 3.75 km/h.
+`--map-scaling` | `Integer` | Scaling of the created map (e.g. 10000 for scaling of 1:10'000), if not specified the scaling will be automatically chosen.
+`--open-images` | None | If this flag is set, the created images will be shown (i.g. the map and elevation plot will be opened after its creation). For this feature a desktop environment is needed.
 
 ## About swisstopo Services
 

--- a/python_program/automatic_walk_time_tables/create_map.py
+++ b/python_program/automatic_walk_time_tables/create_map.py
@@ -1,10 +1,10 @@
 import math
+import os
 from io import BytesIO
 
 import gpxpy
 import grequests
 import numpy as np
-import os
 from PIL import Image, ImageDraw
 
 from . import coord_transformation
@@ -26,6 +26,8 @@ TILE_MATRIX_SET: str = '2056'
 def plot_route_on_map(raw_gpx_data: gpxpy.gpx,
                       way_points: [],
                       file_name: str,
+                      open_figure: bool,
+                      map_scaling: int,
                       layer: str = 'ch.swisstopo.pixelkarte-farbe',
                       tile_format_ext: str = 'jpeg'):
     """
@@ -38,6 +40,10 @@ def plot_route_on_map(raw_gpx_data: gpxpy.gpx,
     layer : Map layer, see https://wmts.geo.admin.ch/EPSG/2056/1.0.0/WMTSCapabilities.xml for options
 
     """
+
+    # Todo: Implement user defined scaling!
+    if map_scaling is not None:
+        print('User defined map scaling will be ignored!')
 
     lv03_min, lv03_max = gpx_utils.calc_perimeter(raw_gpx_data)
 
@@ -120,12 +126,14 @@ def plot_route_on_map(raw_gpx_data: gpxpy.gpx,
         draw.ellipse(circle_coords, outline=(255, 0, 0), width=5)
 
     # Check if output directory exists, if not, create it.
-    if(not os.path.exists('output')):
+    if (not os.path.exists('output')):
         os.mkdir('output')
 
     # saves the image as '.jpg'
     card_snippet_as_image.save('output/' + file_name + '_map.png')
-    card_snippet_as_image.show()
+
+    if open_figure:
+        card_snippet_as_image.show()
 
 
 def calc_img_coord(image_size, lv03_min, pixels_per_meter, wgs84_point):

--- a/python_program/automatic_walk_time_tables/requirements.txt
+++ b/python_program/automatic_walk_time_tables/requirements.txt
@@ -5,3 +5,4 @@ geopy==2.2.0
 openpyxl==3.0.7
 matplotlib==3.4.3
 grequests==0.6.0
+argparse==1.4.0

--- a/python_program/automatic_walk_time_tables/walk_table.py
+++ b/python_program/automatic_walk_time_tables/walk_table.py
@@ -1,23 +1,24 @@
 import math
+import os
 from datetime import timedelta
 from typing import Tuple, List
 
 import gpxpy
-import os
 import numpy as np
 import openpyxl
 from gpxpy.gpx import GPXTrackPoint
 from matplotlib import pyplot as plt
 
+from . import coord_transformation
 from . import find_swisstopo_name
 from . import find_walk_table_points
-from . import coord_transformation 
 
 
 def plot_elevation_profile(raw_data_points: gpxpy.gpx,
                            way_points: List[Tuple[int, GPXTrackPoint]],
                            temp_points: List[Tuple[int, GPXTrackPoint]],
-                           file_name: str):
+                           file_name: str,
+                           open_figure: bool):
     """
 
     Plots the elevation profile of the path contained in the GPX-file. In addition the
@@ -51,12 +52,14 @@ def plot_elevation_profile(raw_data_points: gpxpy.gpx,
     plt.grid(color='gray', linestyle='dashed', linewidth=0.5)
 
     # Check if output directory exists, if not, create it.
-    if(not os.path.exists('output')):
+    if (not os.path.exists('output')):
         os.mkdir('output')
 
     # show the plot and save image
     plt.savefig('output/' + file_name + '_elevation_profile.png', dpi=750)
-    plt.show()
+
+    if open_figure:
+        plt.show()
 
 
 def create_walk_table(time_stamp, speed, way_points, total_distance, file_name: str):
@@ -120,7 +123,7 @@ def create_walk_table(time_stamp, speed, way_points, total_distance, file_name: 
     print()
 
     # Check if output directory exists, if not, create it.
-    if(not os.path.exists('output')):
+    if (not os.path.exists('output')):
         os.mkdir('output')
 
     xfile.save('output/' + file_name + '_Marschzeittabelle.xlsx')

--- a/python_program/main.py
+++ b/python_program/main.py
@@ -1,13 +1,14 @@
+import argparse
 from datetime import datetime
 
 import gpxpy.gpx
 
-from automatic_walk_time_tables.find_walk_table_points import select_waypoints
 from automatic_walk_time_tables.create_map import plot_route_on_map
+from automatic_walk_time_tables.find_walk_table_points import select_waypoints
 from automatic_walk_time_tables.walk_table import plot_elevation_profile, create_walk_table
 
 
-def generate_automated_walk_table(departure_date, gpx_file_path, velocity):
+def generate_automated_walk_table(departure_date, gpx_file_path, velocity, open_figure: bool, map_scaling: int):
     # Open GPX-File with the way-points
     gpx_file = open(gpx_file_path, 'r')
     raw_gpx_data = gpxpy.parse(gpx_file)
@@ -17,19 +18,36 @@ def generate_automated_walk_table(departure_date, gpx_file_path, velocity):
 
     # calc Points for walk table
     total_distance, temp_points, way_points = select_waypoints(raw_gpx_data)
-    plot_elevation_profile(raw_gpx_data, way_points, temp_points, file_name=name)
+    plot_elevation_profile(raw_gpx_data, way_points, temp_points, file_name=name, open_figure=open_figure)
     create_walk_table(departure_date, velocity, way_points, total_distance, file_name=name)
-    plot_route_on_map(raw_gpx_data, way_points, file_name=name)
+    plot_route_on_map(raw_gpx_data, way_points, file_name=name, open_figure=open_figure, map_scaling=map_scaling)
 
 
 if __name__ == "__main__":
-    # defines the departure time of the hike
-    DEPARTURE_TIME = datetime(year=2021, month=8, day=16, hour=9, minute=00)
+    # Initialize parser
+    msg = "Supported command-line args: "
+    parser = argparse.ArgumentParser(description=msg)
 
-    # Path to the GPX-File with the pre-planed route
-    GPX_FILE_PATH = './GPX/CHANGE_ME.gpx'
+    # Adding arguments
+    parser.add_argument('--gpx-file-name', type=str,
+                        help='Name and path to the GPX file, if not specified ./GPX/Default_Route.gpx will be used as '
+                             'default value.', default='./GPX/Default_Route.gpx')
+    parser.add_argument('--velocity', type=float, default=3.75,
+                        help='Float. Speed in km/h on which the calculation is based, default 3.75 km/h.')
+    parser.add_argument('--map-scaling', type=int,
+                        help='Integer. Scaling of the created map (e.g. 10000 for scaling of 1:10\'000), if not '
+                             'specified the scaling will be automatically chosen.')
+    parser.add_argument('--open_figure', default=False, action='store_true',
+                        help='If this flag is set, the created images will be shown (i.g. the map and elevation plot '
+                             'will be opened after its creation). For this feature a desktop environment is needed.')
+    parser.add_argument('--departure-time', type=lambda s: datetime.fromisoformat(s),
+                        default=datetime(year=2021, month=8, day=16, hour=9, minute=00),
+                        help='Departure date in ISO-format, i.g. 2011-11-04T00:05:23. Default 2021-08-16T09:00:00.')
 
-    # Velocity , walk-speed in km/h
-    VELOCITY = 3.75
+    args = parser.parse_args()
 
-    generate_automated_walk_table(DEPARTURE_TIME, GPX_FILE_PATH, VELOCITY)
+    generate_automated_walk_table(departure_date=args.departure_time,
+                                  gpx_file_path=args.gpx_file_name,
+                                  velocity=args.velocity,
+                                  open_figure=args.open_figure,
+                                  map_scaling=args.map_scaling)


### PR DESCRIPTION
## Changes of this pull request

- Fix #11 by adding a command-line flag for auto-opening created images. @maede97 can you test this in your setup?
- Add command-line argument for GPX-file-name, velocity, and departure-time. See [README.md](https://github.com/cevi/automatic_walk-time_tables/blob/61535a08e4e2dfedab45145398ef543e6bb79e4c/python_program/Readme.md).
- Prepare an enhancement #8: Add command-line argument, but if a user scale is defined it will be ignored at the moment.

## Todo before merging
- [ ] Implement a solution for #8.
- [ ] Test fix of #11 in non desktop enviroment.
- [ ] Test all command-line options.


