### PR TITLE
fix for #66

### DIFF
--- a/python_program/automatic_walk_time_tables/geo_processing/map_numbers.py
+++ b/python_program/automatic_walk_time_tables/geo_processing/map_numbers.py
@@ -18,12 +18,18 @@ def is_in_bbox(bbox: List[float], pt : point.Point_LV03) -> bool:
 
 def sort_maps(s: str) -> int:
     """
-    Carves out the LK number and returns it as an integer
+    Carves out the LK or CN number and returns it as an integer
     This can be used to sort a list of map names.
 
     Sometimes, multiple map numbers are given XXXX/YYYY, so we only want the first one.
     """
-    return int(s.split("(")[1].split(")")[0].split("LK ")[1].split("/")[0])
+
+    unbracketed_str = s.split("(")[1].split(")")[0]
+
+    if 'CN ' in unbracketed_str:
+        return int(unbracketed_str.split("CN ")[1].split("/")[0])
+
+    return int(unbracketed_str.split("LK ")[1].split("/")[0])
 
 
 def find_map_numbers(path_ : path.Path) -> str:

--- a/webinterface/package.json
+++ b/webinterface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automatic-walk-time-tables",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
Fixes a problem by the parsing of the API result for the LK numbers.

The problem is, that the API sometimes also responds with CN numbers, not only LK numbers. That caused the original code to crash. If added a check to differentiate between CN and LK numbers in the extracting function. Note, this is a temporary fix, as #42 will change this process anyway.