### PR TITLE
Use the correct backend

### DIFF
--- a/.github/workflows/prod_build.yml
+++ b/.github/workflows/prod_build.yml
@@ -1,4 +1,4 @@
-name: DevBuild
+name: Productiv / Deployment Build
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - 'master'
 
 env:
-  ANGULAR_CONFIGURATION: dev_build
+  ANGULAR_CONFIGURATION: production
 
 jobs:
   prodBuild:

--- a/pdf_map_export/swisstopo_config/config.yaml
+++ b/pdf_map_export/swisstopo_config/config.yaml
@@ -1,12 +1,12 @@
-proxies:
-  - !proxy
-    scheme: http
-    host: awt-tile-cache
-    port: 8080
-    matchers:
-      - !localMatch
-        reject: true
-      - !acceptAll { }
+# proxies:
+#   - !proxy
+#     scheme: http
+#     host: awt-tile-cache
+#     port: 8080
+#     matchers:
+#       - !localMatch
+#         reject: true
+#       - !acceptAll { }
 
 templates:
 

--- a/python_program/automatic_walk_time_tables/map_downloader/create_map.py
+++ b/python_program/automatic_walk_time_tables/map_downloader/create_map.py
@@ -351,7 +351,7 @@ class MapCreator:
             image_type = 'png'
 
         return {
-            "baseURL": "http://wmts.geo.admin.ch/1.0.0/{Layer}/{style}/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}." + image_type,
+            "baseURL": "https://wmts.geo.admin.ch/1.0.0/{Layer}/{style}/{Time}/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}." + image_type,
             "dimensions": ["Time"],
             "dimensionParams": {"Time": "current"},
             "name": layer,

--- a/webinterface/package.json
+++ b/webinterface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "automatic-walk-time-tables",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "scripts": {
     "ng": "ng",
     "start": "angular-build-info && ng serve",


### PR DESCRIPTION
The production image should always use the production environment.

should fix #95, but currently I cannot test it myself.