### PR TITLE
Validate Form Input for POIs

### DIFF
--- a/webinterface/src/app/pages/export-settings/export-settings.component.ts
+++ b/webinterface/src/app/pages/export-settings/export-settings.component.ts
@@ -87,8 +87,11 @@ export class ExportSettingsComponent implements OnInit {
       if (option === 'auto-scale')
         continue;
 
-      console.log(this.options.controls[option].value)
-      url += '&--' + option + '=' + this.options.controls[option].value.toString().replaceAll('\n', ';')
+      const setting = this.options.controls[option].value
+        .toString().replaceAll('\n', ';').replaceAll(' ', '');  // remove spaces and linebreaks
+
+      console.log(option + ": " + setting)
+      url += '&--' + option + '=' + setting;
 
     }
 


### PR DESCRIPTION
Fixes #104 

Missformated input crashed the backend server, i.g. if a user added spaces to its POI list, the backend server crashed.
This PR adds a front-end side check to prevent misformatted inputs via the front end.

A backend side check will be implemented with the translation to a JSON-based settings transition (see https://github.com/cevi/automatic_walk-time_tables/pull/91#issue-1329870021)