### PR TITLE
Prebuild Frontend

### DIFF
--- a/docs/documentation/introduction/environment.md
+++ b/docs/documentation/introduction/environment.md
@@ -28,7 +28,7 @@ The following runtime modes are available:
 | Environment   | Purpose                                                                                                                                       | Default Domain Binding |
 |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|------------------------|
 | `prod-latest` | Production runtime environment, as hosted on [map.cevi.tool](https://map.cevi.tool).                                                          | `map.cevi.tool`        |
-| `prod-dev`    | Same as production mode but with different environment variables and image tags. As hosted on [dev.map.cevi.tool](https://dev.map.cevi.tool). | `localhost`            |
+| `prod-dev`    | Same as production mode but with different environment variables and image tags. As hosted on [dev.map.cevi.tool](https://dev.map.cevi.tool). | `dev.map.cevi.tool`    |
 | `live`        | Development runtime environment with enabled live reloading/rebuilding usefully to develop the application                                    | `localhost`            |
 | `test`        | Used to test the application                                                                                                                  | `localhost`            |
 

--- a/docs/documentation/introduction/environment.md
+++ b/docs/documentation/introduction/environment.md
@@ -8,7 +8,7 @@ We distinguish between runtime modes and environment files. The former are defin
 Runtime modes and environment Variables may influence the behaviour of the application.
 
 ::: tip
-The default runtime mode is `dev-live` with it's associated configuration file `.env.dev-live`.
+The default runtime mode is `live` with it's associated configuration file `.env.live`.
 
 It enables live reloading/rebuilding, which is useful to develop the application.
 :::

--- a/webinterface/create_build_info.sh
+++ b/webinterface/create_build_info.sh
@@ -5,8 +5,16 @@
 timestamp=$(date "+%a %b %d %Y %H:%M:%S GMT%z (%Z)")
 
 version=$(node -pe "require('./package.json').version")
-git_commit=$(cat .git/$(cat .git/HEAD | cut -d' ' -f2))
-git_branch=$(cat .git/HEAD | cut -d'/' -f3)
+
+# check if .git directory exists and contains a HEAD file
+if [ -f ".git/HEAD" ]; then
+  git_commit=$(cat .git/$(cat .git/HEAD | cut -d' ' -f2))
+  git_branch=$(cat .git/HEAD | cut -d'/' -f3)
+else # set default values
+  git_commit="unknown"
+  git_branch="unknown"
+fi
+
 
 build_info="
 const build = {

--- a/webinterface/live.Dockerfile
+++ b/webinterface/live.Dockerfile
@@ -14,5 +14,8 @@ RUN npm install -g typescript
 # Copy project directory
 COPY ./webinterface/ /app/
 
+# Prebuilds the angular application
+RUN npm run build:docker
+
 # Generate the build of the application. Note how we copy the node-context folder
 CMD ls && npm run start:docker


### PR DESCRIPTION
This PR addresses #115. This should only affect the runtime mode: `live`.

Enable rebuilding of the frontend during the building of the docker images. This reduces the time between the `webinterface` container being marked as `up`, and the webserver responding to requests by a factor of 2x.

## Measured Runtimes
(Times averaged over 3 runs)

| |  `docker-compose up -d`  |  time before first request is served  |
|---|---|---|
| without pre-building | 2.77s | 16.47s |
| with pre-buildig | 2.58s | 8.74s |
