### PR TITLE
Implements basic Functionality to Draw Routes directly within map.cevi.tools

### DIFF
--- a/.env.ci-testing
+++ b/.env.ci-testing
@@ -5,6 +5,7 @@ DOCS_DOMAIN=http://awt-docs:4000
 FRONTEND_DOMAIN=http://awt-frontend
 PRINT_API_BASE_URL=awt-mapfish-print-server
 CYPRESS_BASE_URL=http://awt-frontend
+VALHALLA_DOMAIN=http://awt-valhalla:8002
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.env.local-dev
+++ b/.env.local-dev
@@ -4,6 +4,7 @@ BACKEND_DOMAIN=http://localhost:5000
 DOCS_DOMAIN=http://localhost:4000
 FRONTEND_DOMAIN=http://localhost
 PRINT_API_BASE_URL=awt-mapfish-print-server
+VALHALLA_DOMAIN=http://localhost:8002
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.env.prod-dev
+++ b/.env.prod-dev
@@ -4,7 +4,7 @@ BACKEND_DOMAIN=https://backend.dev.map.cevi.tools/
 DOCS_DOMAIN=http://docs.dev.map.cevi.tools
 FRONTEND_DOMAIN=https://dev.map.cevi.tools
 PRINT_API_BASE_URL=awt-mapfish-print-server
-VALHALLA_DOMAIN=http://valhalla.dev.map.cevi.tools
+VALHALLA_DOMAIN=https://valhalla.dev.map.cevi.tools
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.env.prod-dev
+++ b/.env.prod-dev
@@ -4,6 +4,7 @@ BACKEND_DOMAIN=https://backend.dev.map.cevi.tools/
 DOCS_DOMAIN=http://docs.dev.map.cevi.tools
 FRONTEND_DOMAIN=https://dev.map.cevi.tools
 PRINT_API_BASE_URL=awt-mapfish-print-server
+VALHALLA_DOMAIN=http://valhalla.dev.map.cevi.tools
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.env.prod-latest
+++ b/.env.prod-latest
@@ -4,6 +4,7 @@ BACKEND_DOMAIN=https://backend.map.cevi.tools
 DOCS_DOMAIN=http://docs.map.cevi.tools
 FRONTEND_DOMAIN=https://map.cevi.tools
 PRINT_API_BASE_URL=awt-mapfish-print-server
+VALHALLA_DOMAIN=http://valhalla.map.cevi.tools
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.env.prod-latest
+++ b/.env.prod-latest
@@ -4,7 +4,7 @@ BACKEND_DOMAIN=https://backend.map.cevi.tools
 DOCS_DOMAIN=http://docs.map.cevi.tools
 FRONTEND_DOMAIN=https://map.cevi.tools
 PRINT_API_BASE_URL=awt-mapfish-print-server
-VALHALLA_DOMAIN=http://valhalla.map.cevi.tools
+VALHALLA_DOMAIN=https://valhalla.map.cevi.tools
 
 # Configures the logging level for the backend
 # valid values are DEBUG, INFO, WARNING, ERROR or CRITICAL

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,11 +15,6 @@ jobs:
       - name: 🛎️  Checkout
         uses: actions/checkout@v4
 
-      # Restores the cache if it exists.
-      - name: ⛏ Restore docker image from cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: create dumy files for ./git/HEAD and ./git/refs/heads/
         run: |
           mkdir -p .git/refs/heads

--- a/backend/automatic_walk_time_tables/path_transformers/pois_transfomer.py
+++ b/backend/automatic_walk_time_tables/path_transformers/pois_transfomer.py
@@ -1,7 +1,6 @@
 import logging
 
 import numpy as np
-
 from automatic_walk_time_tables.path_transformers.path_transfomer import PathTransformer
 from automatic_walk_time_tables.utils.path import Path
 from automatic_walk_time_tables.utils.point import Point_LV95
@@ -25,7 +24,6 @@ class POIsTransformer(PathTransformer):
         elif self.pois_list_as_str != "":
             return self.pois_from_string(path)
 
-        # TODO: calc points of interest if list is empty
         else:
             return self.calc_pois(path)
 
@@ -95,8 +93,20 @@ class POIsTransformer(PathTransformer):
         # calc extremums of path_
         max_index = np.argmax([p.point.h for p in path.way_points])
         min_index = np.argmin([p.point.h for p in path.way_points])
-        pois.insert(path.way_points[max_index])
-        pois.insert(path.way_points[min_index])
+
+        # we add extremums to the list of points of interest if they are at least 100m away from the endpoint
+        if (
+            path.way_points[max_index].point.distance(path.way_points[0].point) >= 100
+            and path.way_points[min_index].point.distance(path.way_points[0].point)
+            >= 100
+        ):
+            pois.insert(path.way_points[max_index])
+        if (
+            path.way_points[min_index].point.distance(path.way_points[-1].point) >= 100
+            and path.way_points[max_index].point.distance(path.way_points[-1].point)
+            >= 100
+        ):
+            pois.insert(path.way_points[min_index])
 
         # add endpoint to list of points of interest
         pois.append(path.way_points[-1])

--- a/backend/automatic_walk_time_tables/utils/file_parser.py
+++ b/backend/automatic_walk_time_tables/utils/file_parser.py
@@ -69,8 +69,36 @@ class GeoFileParser(object):
             return self.__parse_gpx_file(file_content)
         elif extension == "kml":
             return self.parse_kml_file__(file_content)
+        elif extension == "array":
+            return self.parse_array_file__(file_content)
         else:
             raise Exception("Unsupported file format")
+
+    def parse_array_file__(self, raw_data: str) -> path.Path:
+
+        coordinates = raw_data.split(";")
+        coordinates = [c.split(",") for c in coordinates]
+
+        if len(coordinates[0]) == 2:
+            coordinates = [
+                point.Point_LV95(float(c[0]), float(c[1])) for c in coordinates
+            ]
+        else:
+            coordinates = [
+                point.Point_LV95(float(c[0]), float(c[1]), float(c[2]))
+                for c in coordinates
+            ]
+
+        path_ = path.Path(coordinates)
+
+        if not path_.has_elevation_for_all_points():
+            path_ = self.height_fetcher.transform(path_)
+        else:
+            pass
+
+
+        return path_
+
 
     def __parse_gpx_file(self, gpx_raw_data: str) -> path.Path:
         gpx: gpxpy.gpx = gpxpy.parse(gpx_raw_data)

--- a/backend/automatic_walk_time_tables/utils/file_parser.py
+++ b/backend/automatic_walk_time_tables/utils/file_parser.py
@@ -96,9 +96,7 @@ class GeoFileParser(object):
         else:
             pass
 
-
         return path_
-
 
     def __parse_gpx_file(self, gpx_raw_data: str) -> path.Path:
         gpx: gpxpy.gpx = gpxpy.parse(gpx_raw_data)

--- a/docker-compose.ci-testing.yml
+++ b/docker-compose.ci-testing.yml
@@ -85,3 +85,19 @@ services:
 
     logging:
       driver: none
+
+  awt-valhalla:
+    build:
+      context: ./route_engine
+      dockerfile: Dockerfile
+    environment:
+      # - tile_urls=https://download.geofabrik.de/europe/switzerland-latest.osm.pbf
+      - server_threads=2  # determines how many threads will be used to run the valhalla server
+      - use_tiles_ignore_pbf=True  # load existing valhalla_tiles.tar directly
+      - build_elevation=False  # build elevation with "True" or "Force": will download only the elevation for areas covered by the graph tiles
+      - build_admins=False  # build admins db with "True" or "Force"
+      - build_time_zones=False  # build timezone db with "True" or "Force"
+      - build_tar=True  # build an indexed tar file from the tile_dir for faster graph loading times
+      - force_rebuild=False  # forces a rebuild of the routing tiles with "True"
+    env_file:
+      - .env.ci-testing

--- a/docker-compose.prod-dev.yml
+++ b/docker-compose.prod-dev.yml
@@ -49,3 +49,20 @@ services:
     image: registry.cevi.tools/cevi/awt_frontend:dev
     env_file:
       - .env.prod-dev
+
+  awt-valhalla:
+    build:
+      context: ./route_engine
+      dockerfile: Dockerfile
+    image: registry.cevi.tools/cevi/awt_valhalla:dev
+    environment:
+      # - tile_urls=https://download.geofabrik.de/europe/switzerland-latest.osm.pbf
+      - server_threads=2  # determines how many threads will be used to run the valhalla server
+      - use_tiles_ignore_pbf=True  # load existing valhalla_tiles.tar directly
+      - build_elevation=False  # build elevation with "True" or "Force": will download only the elevation for areas covered by the graph tiles
+      - build_admins=False  # build admins db with "True" or "Force"
+      - build_time_zones=False  # build timezone db with "True" or "Force"
+      - build_tar=True  # build an indexed tar file from the tile_dir for faster graph loading times
+      - force_rebuild=False  # forces a rebuild of the routing tiles with "True"
+    env_file:
+      - .env.prod-dev

--- a/docker-compose.prod-latest.yml
+++ b/docker-compose.prod-latest.yml
@@ -49,3 +49,20 @@ services:
     image: registry.cevi.tools/cevi/awt_frontend:latest
     env_file:
       - .env.prod-latest
+
+  awt-valhalla:
+    build:
+      context: ./route_engine
+      dockerfile: Dockerfile
+    image: registry.cevi.tools/cevi/awt_valhalla:latest
+    environment:
+      # - tile_urls=https://download.geofabrik.de/europe/switzerland-latest.osm.pbf
+      - server_threads=2  # determines how many threads will be used to run the valhalla server
+      - use_tiles_ignore_pbf=True  # load existing valhalla_tiles.tar directly
+      - build_elevation=False  # build elevation with "True" or "Force": will download only the elevation for areas covered by the graph tiles
+      - build_admins=False  # build admins db with "True" or "Force"
+      - build_time_zones=False  # build timezone db with "True" or "Force"
+      - build_tar=True  # build an indexed tar file from the tile_dir for faster graph loading times
+      - force_rebuild=False  # forces a rebuild of the routing tiles with "True"
+    env_file:
+      - .env.prod-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
 
   awt-docs:
@@ -99,7 +97,9 @@ services:
       retries: 180
 
   awt-route_engine:
-    image: ghcr.io/gis-ops/docker-valhalla/valhalla:latest
+    build:
+      context: ./route_engine
+      dockerfile: Dockerfile
     ports:
       - "8002:8002"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       - "80:80"
     depends_on:
       - awt-backend
-      - awt-route_engine
+      - awt-valhalla
     env_file:
       - .env.local-dev
     healthcheck:
@@ -96,10 +96,10 @@ services:
       timeout: 1s
       retries: 180
 
-  awt-route_engine:
+  awt-valhalla:
     build:
       context: ./route_engine
-      dockerfile: Dockerfile
+      dockerfile: dev.Dockerfile
     ports:
       - "8002:8002"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - "80:80"
     depends_on:
       - awt-backend
+      - awt-route_engine
     env_file:
       - .env.local-dev
     healthcheck:
@@ -96,6 +97,24 @@ services:
       interval: 5s
       timeout: 1s
       retries: 180
+
+  awt-route_engine:
+    image: ghcr.io/gis-ops/docker-valhalla/valhalla:latest
+    ports:
+      - "8002:8002"
+    volumes:
+      - ./route_engine/sources/:/custom_files
+    environment:
+      # - tile_urls=https://download.geofabrik.de/europe/switzerland-latest.osm.pbf
+      - server_threads=2  # determines how many threads will be used to run the valhalla server
+      - use_tiles_ignore_pbf=True  # load existing valhalla_tiles.tar directly
+      - build_elevation=False  # build elevation with "True" or "Force": will download only the elevation for areas covered by the graph tiles
+      - build_admins=False  # build admins db with "True" or "Force"
+      - build_time_zones=False  # build timezone db with "True" or "Force"
+      - build_tar=True  # build an indexed tar file from the tile_dir for faster graph loading times
+      - force_rebuild=False  # forces a rebuild of the routing tiles with "True"
+    env_file:
+      - .env.local-dev
 
 volumes:
   vitepress_dist: {}

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -94,12 +94,12 @@ export default {
                     ]
                 },
                 {
-                    text: 'Routing Engine',
+                    text: 'Route Engine',
                     collapsible: true,
                     collapsed: true,
-                    items: [
+                    items: [reout
                         {
-                            text: 'About', link: '/documentation/routing_engine/about'
+                            text: 'About', link: '/documentation/route_engine/about'
                         },
                     ]
                 },

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -97,7 +97,7 @@ export default {
                     text: 'Route Engine',
                     collapsible: true,
                     collapsed: true,
-                    items: [reout
+                    items: [
                         {
                             text: 'About', link: '/documentation/route_engine/about'
                         },

--- a/docs/documentation/introduction/structure.md
+++ b/docs/documentation/introduction/structure.md
@@ -51,13 +51,13 @@ Source in `./swiss_TLM_api` folder.
 
 More info can be found here: [Swiss TLM API](../swiss_TLM_api/about.md).
 
-## Routing Engine
+## Route Engine
 
 ::: info
-Source in `./routing_engine` folder.
+Source in `./route_engine` folder.
 :::
 
-More info can be found here: [Routing Engine](../routing_engine/about.md).
+More info can be found here: [Route Engine](../route_engine/about.md).
 
 ## Documentation
 

--- a/docs/documentation/route_engine/about.md
+++ b/docs/documentation/route_engine/about.md
@@ -1,0 +1,3 @@
+# Route Engine (Valhalla)
+
+Details can be found on GitHub: [Route Engine](https://github.com/valhalla/valhalla).

--- a/docs/documentation/routing_engine/about.md
+++ b/docs/documentation/routing_engine/about.md
@@ -1,3 +1,0 @@
-# Routing Engine (Valhalla)
-
-Details can be found on GitHub: [Routing Engine](https://github.com/valhalla/valhalla).

--- a/frontend/set-env.ts
+++ b/frontend/set-env.ts
@@ -10,6 +10,7 @@ require('dotenv').load();
 const envConfigFile = `export const environment = {
    production: ${process.env.ANGULAR_BUILD_MODE == 'production' ? 'true' : 'false'},
    API_URL: '${process.env.BACKEND_DOMAIN}/',
+   VALHALLA_URL: '${process.env.VALHALLA_DOMAIN}/',
    DOCS_URL: '${process.env.DOCS_DOMAIN}/',
 };
 `;

--- a/frontend/src/app/components/upload-area/upload-area.component.html
+++ b/frontend/src/app/components/upload-area/upload-area.component.html
@@ -4,7 +4,7 @@
   <span class="action-description"> Drag-and-Drop GPX- / KML-Datei </span>
   <span class="small-font"> oder </span>
 
-  <button mat-stroked-button color="primary" class="select-file" > GPX- / KML-Datei auswählen </button>
-  <input type="file" id="uploader" accept=".gpx,.kml" (input)="file_added($event)">
+  <button mat-stroked-button color="primary" class="select-file" (click)="fileSelect.click()"> GPX- / KML-Datei auswählen </button>
+  <input type="file" id="uploader" accept=".gpx,.kml" (input)="file_added($event)" #fileSelect>
 
 </div>

--- a/frontend/src/app/pages/export-settings/export-settings.component.html
+++ b/frontend/src/app/pages/export-settings/export-settings.component.html
@@ -20,7 +20,7 @@
 
         <div class="content-block">
 
-          <h3>Route Zeichnen [alpha]</h3>
+          <h3>Route Zeichnen [experimentell]</h3>
           <p>Starte deine Route mit einem Klick auf die Landeskarte.</p>
 
           <button (click)="finish_drawing()" matStepperNext mat-stroked-button color="primary" [disabled]="!has_valid_path">Zeichnen Abschliessen

--- a/frontend/src/app/pages/export-settings/export-settings.component.html
+++ b/frontend/src/app/pages/export-settings/export-settings.component.html
@@ -16,11 +16,20 @@
 
       <mat-step [hasError]="!route_uploaded" errorMessage="Route fehlt! Bitte Datei hochladen.">
 
-        <ng-template matStepLabel>Route Hochladen</ng-template>
+        <ng-template matStepLabel>Route Hochladen oder Zeichnen</ng-template>
 
         <div class="content-block">
+
+          <h3>Route Zeichnen [alpha]</h3>
+          <p>Starte deine Route mit einem Klick auf die Landeskarte.</p>
+
+          <button (click)="finish_drawing()" matStepperNext mat-stroked-button color="primary" [disabled]="!has_valid_path">Zeichnen Abschliessen
+          </button>
+
+          <h3>oder Route Hochladen</h3>
           <p>
-            Lade eine GPX-Datei hoch, diese kannst du aus SchweizMobil oder der Swisstopo-App exportieren. Alternativ
+            Alternativ kannst du eine GPX-Datei hochladen, diese kannst du aus SchweizMobil oder der Swisstopo-App
+            exportieren. Alternativ
             kannst du eine KML-Datei hochladen, die du sie vom Kartenviewer von Swisstopo exportieren kannst.
           </p>
 

--- a/frontend/src/app/pages/export-settings/export-settings.component.ts
+++ b/frontend/src/app/pages/export-settings/export-settings.component.ts
@@ -58,12 +58,11 @@ export class ExportSettingsComponent {
     console.log('Form values:', this.options.value);
     this.mapAnimator?.path$.subscribe((path) => {
       this.has_valid_path = path.length !== 0;
+      this.route_uploaded = this.has_valid_path;
     });
 
 
   }
-
-
 
 
   public new_route_uploaded(route_file: File) {

--- a/frontend/src/app/pages/export-settings/export-settings.component.ts
+++ b/frontend/src/app/pages/export-settings/export-settings.component.ts
@@ -20,6 +20,7 @@ export class ExportSettingsComponent {
   public loading = false;
   public error_message: string = '';
   protected readonly location = location;
+  public has_valid_path: boolean = false;
 
   constructor(private mapAnimator: MapAnimatorService, fb: UntypedFormBuilder, private router: Router) {
 
@@ -54,8 +55,15 @@ export class ExportSettingsComponent {
       // safe to ignore
     }
 
+    console.log('Form values:', this.options.value);
+    this.mapAnimator?.path$.subscribe((path) => {
+      this.has_valid_path = path.length !== 0;
+    });
+
 
   }
+
+
 
 
   public new_route_uploaded(route_file: File) {
@@ -104,4 +112,10 @@ export class ExportSettingsComponent {
   }
 
 
+  async finish_drawing() {
+
+    this.route_uploaded = true;
+    await this.mapAnimator.finish_drawing();
+
+  }
 }

--- a/frontend/src/app/services/map-animator.service.ts
+++ b/frontend/src/app/services/map-animator.service.ts
@@ -319,5 +319,18 @@ export class MapAnimatorService {
 
   }
 
+  public delete_poi(point: LV95_Waypoint) {
+
+    this.pois$.pipe(take(1)).subscribe(pois => {
+      this._pois$.next(pois.filter(p => p.x != point.x || p.y != point.y));
+    });
+
+    combineLatest([this._path$, this._pois$, this.way_points$]).pipe(take(1))
+      .subscribe(([path, pois, way_points]) =>
+        this.create_walk_time_table(path, pois).catch(err => this._error_handler(err))
+      );
+
+  }
+
 
 }

--- a/frontend/src/app/services/map-animator.service.ts
+++ b/frontend/src/app/services/map-animator.service.ts
@@ -4,6 +4,7 @@ import {BehaviorSubject, combineLatest, Observable} from "rxjs";
 import {decode, encode, LatLngTuple} from "@googlemaps/polyline-codec";
 import {environment} from "../../environments/environment";
 import {take} from "rxjs/operators";
+import {transform} from "ol/proj";
 
 @Injectable({
   providedIn: 'root'
@@ -19,6 +20,7 @@ export class MapAnimatorService {
   private readonly _map_center$: BehaviorSubject<LV95_Coordinates>;
   private _error_handler: (err: string) => void;
 
+  public has_route = false;
 
   private readonly _pointer$: BehaviorSubject<LV95_Coordinates | null>;
 
@@ -61,6 +63,7 @@ export class MapAnimatorService {
 
 
   public clear() {
+    this.has_route = false;
     this._path$.next([]);
     this._way_points$.next([]);
     this._pois$.next([]);
@@ -143,26 +146,38 @@ export class MapAnimatorService {
 
   /**
    *
-   * @param route_file
+   * @param route_file_or_array
    * @returns {Promise<string>} the name of the route
    *
    */
-  public async replace_route(route_file: File | undefined): Promise<string> {
+  public async replace_route(route_file_or_array: File | LV95_Coordinates[] | undefined): Promise<string> {
 
-    if (!route_file) {
+    if (!route_file_or_array) {
       this.clear();
+      this.has_route = false;
       throw new Error('No route file selected');
     }
 
+    this.has_route = true;
+
+
     // minify XML data
-    let xml_string = (await route_file.text()).toString()
-    xml_string = xml_string.replace(/>\s*/g, '>');  // Remove space after >
-    xml_string = xml_string.replace(/\s*</g, '<');  // Remove space before <
+    let xml_string;
+    let file_type;
+    if (route_file_or_array instanceof File) {
+      xml_string = (await route_file_or_array.text()).toString()
+      xml_string = xml_string.replace(/>\s*/g, '>');  // Remove space after >
+      xml_string = xml_string.replace(/\s*</g, '<');  // Remove space before <
+      file_type = route_file_or_array.name.split('.').pop();
+    } else {
+      xml_string = route_file_or_array.map(p => `${p.x},${p.y}`).join(';');
+      file_type = 'array';
+    }
 
     let formData = new FormData();
     formData.append("options", JSON.stringify({
       'encoding': 'polyline',
-      'file_type': route_file.name.split('.').pop()
+      'file_type': file_type
     }));
     formData.append("file_content", xml_string);
 
@@ -305,6 +320,60 @@ export class MapAnimatorService {
 
   }
 
+  public async add_way_point(point: LV95_Coordinates) {
+
+    const WGS84 = transform([point.x, point.y], 'EPSG:2056', 'EPSG:4326');
+    console.log('Adding way point', point, WGS84);
+
+    const path = this._path$.getValue();
+
+    if (path.length == 0) {
+
+      path.push({
+        'x': point.x,
+        'y': point.y,
+        'h': 0,
+        'accumulated_distance': 0,
+      });
+
+      this._path$.next(path);
+      return;
+
+    }
+
+    const old_WGS84 = transform([path[path.length - 1].x, path[path.length - 1].y], 'EPSG:2056', 'EPSG:4326');
+
+
+    // fetch path from valhalla/valhalla at localhost:8002 with json in url
+    const url = 'http://localhost:8002/route?json=' + encodeURIComponent(JSON.stringify({
+      locations: [
+        {lat: old_WGS84[1], lon: old_WGS84[0]},
+        {lat: WGS84[1], lon: WGS84[0]}
+      ],
+      costing: 'pedestrian',
+      radius: 25
+    }));
+
+    // fetch path from valhalla/valhalla at localhost:8002
+    const data = await fetch(url, {method: 'POST'}).then(response => response.json());
+    const shape: string = data.trip.legs[0].shape;
+
+    const decoded_path = decode(shape, 6).map(p =>
+      transform([p[1], p[0]], 'EPSG:4326', 'EPSG:2056'));
+
+    decoded_path.forEach(p => {
+      path.push({
+        'x': p[0],
+        'y': p[1],
+        'h': 0,
+        'accumulated_distance': 0,
+      });
+    });
+
+    this._path$.next(path);
+
+  }
+
   private create_way_points(path: LatLngTuple[], elevation: LatLngTuple[], names: string[] = []): LV95_Waypoint[] {
 
     return path.map((p: any, i: number) => {
@@ -333,4 +402,16 @@ export class MapAnimatorService {
   }
 
 
+  /**
+   * Finish drawing the route, does the same as the replace_route function but without the file
+   */
+  async finish_drawing() {
+
+    this.has_route = true;
+
+    const path = this._path$.getValue().map(p =>
+      ({x: p.x, y: p.y} as LV95_Coordinates));
+    await this.replace_route(path);
+
+  }
 }

--- a/frontend/src/app/services/map-animator.service.ts
+++ b/frontend/src/app/services/map-animator.service.ts
@@ -327,6 +327,16 @@ export class MapAnimatorService {
 
     const path = this._path$.getValue();
 
+    const pois = this._pois$.getValue();
+    pois.push({
+      'x': point.x,
+      'y': point.y,
+      'h': 0,
+      'accumulated_distance': 0,
+      'name': ''
+    });
+    this._pois$.next(pois);
+
     if (path.length == 0) {
 
       path.push({
@@ -342,7 +352,6 @@ export class MapAnimatorService {
     }
 
     const old_WGS84 = transform([path[path.length - 1].x, path[path.length - 1].y], 'EPSG:2056', 'EPSG:4326');
-
 
     // fetch path from valhalla/valhalla at localhost:8002 with json in url
     const url = 'http://localhost:8002/route?json=' + encodeURIComponent(JSON.stringify({
@@ -408,6 +417,9 @@ export class MapAnimatorService {
   async finish_drawing() {
 
     this.has_route = true;
+
+    // clear pois: as we used them to draw the route
+    this._pois$.next([]);
 
     const path = this._path$.getValue().map(p =>
       ({x: p.x, y: p.y} as LV95_Coordinates));

--- a/frontend/src/app/services/map-animator.service.ts
+++ b/frontend/src/app/services/map-animator.service.ts
@@ -360,6 +360,7 @@ export class MapAnimatorService {
         {lat: WGS84[1], lon: WGS84[0]}
       ],
       costing: 'pedestrian',
+      directions_type: 'none',
       radius: 25
     }));
 

--- a/frontend/src/app/services/map-animator.service.ts
+++ b/frontend/src/app/services/map-animator.service.ts
@@ -11,6 +11,7 @@ import {transform} from "ol/proj";
 })
 export class MapAnimatorService {
 
+  private static VALHALLA_URL = environment.VALHALLA_URL;
   private static BASE_URL = environment.API_URL;
   private static DEFAULT_MAP_CENTER = {x: 2719675, y: 1216320};
 
@@ -353,8 +354,9 @@ export class MapAnimatorService {
 
     const old_WGS84 = transform([path[path.length - 1].x, path[path.length - 1].y], 'EPSG:2056', 'EPSG:4326');
 
-    // fetch path from valhalla/valhalla at localhost:8002 with json in url
-    const url = 'http://localhost:8002/route?json=' + encodeURIComponent(JSON.stringify({
+    // fetch path from valhalla/valhalla
+    // TODO: use environment variable
+    const url = `${MapAnimatorService.VALHALLA_URL}route?json=` + encodeURIComponent(JSON.stringify({
       locations: [
         {lat: old_WGS84[1], lon: old_WGS84[0]},
         {lat: WGS84[1], lon: WGS84[0]}

--- a/frontend/src/app/services/map.service.ts
+++ b/frontend/src/app/services/map.service.ts
@@ -106,6 +106,7 @@ export class MapService extends SwisstopoMap {
 
     });
 
+
     combineLatest([map_animator.way_points$, map_animator.pois$])
       .subscribe(([way_points, pois]) => {
 
@@ -138,7 +139,7 @@ export class MapService extends SwisstopoMap {
 
           feature.setStyle(new Style({
             fill: new Fill({color: '#fff'}),
-            stroke: is_selected ? new Stroke({color: '#2043d7', width: 8}) : new Stroke({color: '#2043d750', width: 8}) ,
+            stroke: is_selected ? new Stroke({color: '#2043d7', width: 8}) : new Stroke({color: '#2043d750', width: 8}),
             text: new Text({
               text: way_point.name,
               fill: new Fill({color: '#2043d7'}),
@@ -154,6 +155,8 @@ export class MapService extends SwisstopoMap {
       });
 
   }
+
+
 
   public draw_map(layerLabel: string = 'pixelkarte', target_canvas: string = 'map-canvas') {
 
@@ -179,6 +182,9 @@ export class MapService extends SwisstopoMap {
 
     this.map?.on('pointermove', async (evt) => {
 
+      // ignore event if in drawing mode
+      if (!this.map_animator?.has_route) return;
+
       const [nearest_point, dist] = await this.get_nearest_path_point(evt);
       if (dist <= 50 && nearest_point) this.map_animator?.move_pointer(nearest_point);
       else this.map_animator?.move_pointer(null);
@@ -187,11 +193,19 @@ export class MapService extends SwisstopoMap {
 
     this.map?.on('click', async (evt) => {
 
-      const [nearest_point, dist] = await this.get_nearest_path_point(evt);
-      const [nearest_poi, dist_poi] = await this.get_nearest_poi(evt);
+      if (this.map_animator?.has_route) {
 
-      if (dist <= 50 && nearest_point && dist_poi >= 50) this.map_animator?.add_point_of_interest(nearest_point);
-      else if (dist_poi <= 50 && nearest_poi) this.map_animator?.delete_poi(nearest_poi);
+        const [nearest_point, dist] = await this.get_nearest_path_point(evt);
+        const [nearest_poi, dist_poi] = await this.get_nearest_poi(evt);
+
+        if (dist <= 50 && nearest_point && dist_poi >= 50) this.map_animator?.add_point_of_interest(nearest_point);
+        else if (dist_poi <= 50 && nearest_poi) this.map_animator?.delete_poi(nearest_poi);
+
+        return
+      }
+
+      console.log('click event', evt.coordinate);
+      await this.map_animator?.add_way_point({x: evt.coordinate[0], y: evt.coordinate[1]});
 
 
     });

--- a/frontend/src/app/services/map.service.ts
+++ b/frontend/src/app/services/map.service.ts
@@ -182,12 +182,17 @@ export class MapService extends SwisstopoMap {
 
     this.map?.on('pointermove', async (evt) => {
 
-      // ignore event if in drawing mode
-      if (!this.map_animator?.has_route) return;
+      if (this.map_animator?.has_route) {
+        const [nearest_point, dist] = await this.get_nearest_path_point(evt);
+        if (dist <= 50 && nearest_point) this.map_animator?.move_pointer(nearest_point);
+        else this.map_animator?.move_pointer(null);
+      } else {
 
-      const [nearest_point, dist] = await this.get_nearest_path_point(evt);
-      if (dist <= 50 && nearest_point) this.map_animator?.move_pointer(nearest_point);
-      else this.map_animator?.move_pointer(null);
+        // draw the pointer (we are in the drawing mode)
+        this.pointer = evt.coordinate;
+        this.pointer_layer_source.clear();
+
+      }
 
     });
 
@@ -204,7 +209,6 @@ export class MapService extends SwisstopoMap {
         return
       }
 
-      console.log('click event', evt.coordinate);
       await this.map_animator?.add_way_point({x: evt.coordinate[0], y: evt.coordinate[1]});
 
 

--- a/route_engine/.gitignore
+++ b/route_engine/.gitignore
@@ -1,0 +1,2 @@
+resources/
+sources/

--- a/route_engine/.gitignore
+++ b/route_engine/.gitignore
@@ -1,2 +1,5 @@
 resources/
 sources/
+
+!resources/.gitkeep
+!sources/.gitkeep

--- a/route_engine/Dockerfile
+++ b/route_engine/Dockerfile
@@ -1,10 +1,13 @@
 FROM ghcr.io/gis-ops/docker-valhalla/valhalla:latest
 
+USER root
+
 # install python
-RUN sudo apt-get update && sudo apt-get install -y python3 python3-pip libgdal-dev
+RUN apt-get update && apt-get install -y python3 python3-pip libgdal-dev
 
 COPY ./entrypoint.sh /entrypoint.sh
-RUN sudo chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
+USER valhalla
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["build_tiles"]

--- a/route_engine/Dockerfile
+++ b/route_engine/Dockerfile
@@ -6,5 +6,8 @@ RUN sudo apt-get update && sudo apt-get install -y python3 python3-pip libgdal-d
 COPY ./entrypoint.sh /entrypoint.sh
 RUN sudo chmod +x /entrypoint.sh
 
+# set user to root
+USER root
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["build_tiles"]

--- a/route_engine/Dockerfile
+++ b/route_engine/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/gis-ops/docker-valhalla/valhalla:latest
+
+# install python
+RUN sudo apt-get update && sudo apt-get install -y python3 python3-pip libgdal-dev
+
+COPY ./entrypoint.sh /entrypoint.sh
+RUN sudo chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["build_tiles"]

--- a/route_engine/README.md
+++ b/route_engine/README.md
@@ -1,0 +1,21 @@
+# Query a Path
+
+```bash
+curl -s -XPOST 'http://localhost:8002/route' -H'Content-Type: application/json' --data-raw '{"locations": [{"lat": 47.32214, "lon":  8.47885}, {"lat": 47.31875, "lon": 8.48224}], "costing": "pedestrian"}'
+```
+
+# Create OSM.PBF file
+
+The route generator needs an `.osm.pbf` file to work. You can create such a file directly from source (i.g. from the raw
+SHP files, which can be downloaded from swisstopo). The following command creates an  `.osm.pbf` file from the raw SHP
+files.
+
+**Note:** You need roughly 32GB of memory on your machine to run this script.
+
+```bash
+# First you need to build the docker container in the `helper_scripts` folder.
+docker build -t shp_to_osm .
+
+# Now you can convert the SHP files to OSM.PBF using:
+docker run shp_to_osm -v /path/to/shp/files:/data
+```

--- a/route_engine/dev.Dockerfile
+++ b/route_engine/dev.Dockerfile
@@ -6,5 +6,8 @@ RUN sudo apt-get update && sudo apt-get install -y python3 python3-pip libgdal-d
 COPY ./entrypoint.sh /entrypoint.sh
 RUN sudo chmod +x /entrypoint.sh
 
+# set user to root
+USER root
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["build_tiles"]

--- a/route_engine/entrypoint.sh
+++ b/route_engine/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# check if /custom_files contains some files apart from .gitkeep
+if ! [ "$(ls -A /custom_files | grep -Ev '.gitkeep' | file_hashes.txt)" ]; then
+
+  echo "No custom files found in /custom_files. Start downloading default files..."
+
+  # Install gdown
+  pip install gdown --break-system-packages
+  export PATH=$PATH:/home/valhalla/.local/bin
+
+  gdown --id 1lkrS268Mphtifxmdw0UHVnR9_cNErNks -O /custom_files/
+
+  echo "Default files downloaded successfully"
+
+fi
+
+# start default entrypoint
+echo "Starting default entrypoint..."
+/valhalla/scripts/run.sh "$@"

--- a/route_engine/entrypoint.sh
+++ b/route_engine/entrypoint.sh
@@ -9,6 +9,10 @@ if ! [ "$(ls -A /custom_files | grep -Ev '.gitkeep' | file_hashes.txt)" ]; then
   pip install gdown --break-system-packages
   export PATH=$PATH:/home/valhalla/.local/bin
 
+  # clear /custom_files
+  sudo rm -rf /custom_files/*
+  sudo chmod 777 /custom_files
+
   gdown --id 1lkrS268Mphtifxmdw0UHVnR9_cNErNks -O /custom_files/
 
   echo "Default files downloaded successfully"

--- a/route_engine/helper_scripts/convert.sh
+++ b/route_engine/helper_scripts/convert.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Check if the folder `/shp_data` exists
+if [ ! -d "/data" ]; then
+    echo "The folder `/data` does not exist"
+    exit 1
+fi
+
+# remove all *.geojson files
+rm -rf /data/*.geojson
+rm -rf /data/*.osm
+rm -rf /data/*.pbf
+
+# split shp files into multiple files
+
+# See https://github.com/roelderickx/ogr2osm
+# use ogr2osm to convert the *.shp to *.osm
+for f in $(find /data/*.shp -type f); do
+    out_f=${f%.shp}.osm
+    ogr2osm -t /converter.py -o $out_f $f
+done
+
+timestamp=$(date +%Y-%m-%dT%H:%M:%S)
+
+# replace "<node" with '<node user=""'
+sed -i 's/<node/<node version="1" timestamp="2022-08-13T03:36:00Z"/g' /data/*.osm
+sed -i 's/<way/<way version="1" timestamp="2022-08-13T03:36:00Z"/g' /data/*.osm
+
+sed -i 's/id="-/id="/g' /data/*.osm
+sed -i 's/ref="-/ref="/g' /data/*.osm
+
+# use osmosis to convert the *.osm to *.osm.pbf
+for f in $(find /data/*.osm -type f); do
+    out_f=${f%.osm}.osm.pbf
+    osmosis --read-xml $f --write-pbf $out_f
+done
+
+exec "$@"

--- a/route_engine/helper_scripts/converter.py
+++ b/route_engine/helper_scripts/converter.py
@@ -1,0 +1,23 @@
+import ogr2osm
+
+class SwissTLMConverter(ogr2osm.TranslationBase):
+
+    def translateName(self, name):
+        return name.strip()
+
+
+    def filter_tags(self, attrs):
+        if not attrs:
+            return
+        tags = {}
+
+        # TODO: differentiate between different road types
+
+        if 'STRNAME' in attrs:
+            translated = self.translateName(attrs['STRNAME'].title())
+            tags['name'] = translated
+
+        if 'OBJEKTART' in attrs:
+            tags['highway'] = 'road'
+
+        return tags

--- a/route_engine/helper_scripts/converter.py
+++ b/route_engine/helper_scripts/converter.py
@@ -1,10 +1,10 @@
 import ogr2osm
 
+
 class SwissTLMConverter(ogr2osm.TranslationBase):
 
     def translateName(self, name):
         return name.strip()
-
 
     def filter_tags(self, attrs):
         if not attrs:
@@ -13,11 +13,11 @@ class SwissTLMConverter(ogr2osm.TranslationBase):
 
         # TODO: differentiate between different road types
 
-        if 'STRNAME' in attrs:
-            translated = self.translateName(attrs['STRNAME'].title())
-            tags['name'] = translated
+        if "STRNAME" in attrs:
+            translated = self.translateName(attrs["STRNAME"].title())
+            tags["name"] = translated
 
-        if 'OBJEKTART' in attrs:
-            tags['highway'] = 'road'
+        if "OBJEKTART" in attrs:
+            tags["highway"] = "road"
 
         return tags


### PR DESCRIPTION
You can now draw simple paths using magnetic ways directly within https://map.cevi.tools/.

## Open Todo's
- [x] add a container to dev and production environment (currently, this is only available if run locally)
- [x] should be merged after https://github.com/cevi/automatic_walk-time_tables/pull/365
- [x] should be merged after https://github.com/cevi/automatic_walk-time_tables/pull/372
- [x] use non-root user for production environment:
https://github.com/cevi/automatic_walk-time_tables/blob/8f6771130f818972e5f98ec0d1c8da0c3591b15e/route_engine/Dockerfile#L10
- [x] add a preview of the next click (e.g. by marking the current cursor position)
- [x] add container to dev deployment (still pending)

## Features Out of Scope of this PR
- [ ] #378 
- [ ] #379
- [ ] #380
- [ ] investigate if we can use https://github.com/geoadmin/routing-graph-packager
- [ ] #381
- [ ] #382
