### PR TITLE
fix: mapfish print and tile cache optimizations

### DIFF
--- a/backend/automatic_walk_time_tables/map_downloader/create_map.py
+++ b/backend/automatic_walk_time_tables/map_downloader/create_map.py
@@ -133,7 +133,7 @@ class MapCreator:
             base_url = "{}://{}:{}".format(
                 print_api_protocol, print_api_base_url, print_api_port
             )
-            url = "{}/print/default/report.pdf".format(base_url)
+            url = "{}/print/swisstopo/report.pdf".format(base_url)
 
             self.logger.debug("Posting to mapfish: " + url)
 

--- a/tile_caching/Dockerfile
+++ b/tile_caching/Dockerfile
@@ -2,5 +2,5 @@ FROM nginx:1.25.3-alpine
 
 ADD nginx.conf /etc/nginx/nginx.conf
 
-# make dir /data/nginx/cache
-RUN mkdir -p /data/nginx/cache
+# make dir /data/nginx/cache and set ownership
+RUN mkdir -p /data/nginx/cache && chown -R nginx:nginx /data/nginx/cache

--- a/tile_caching/nginx.conf
+++ b/tile_caching/nginx.conf
@@ -17,13 +17,33 @@ http {
 
     proxy_cache_path /data/nginx/cache keys_zone=tile_cache:10m;
 
+    # Keep connections alive longer and handle more requests per connection
+    # to prevent NoHttpResponseException on the client side under heavy loads.
+    keepalive_timeout 65s;
+    keepalive_requests 10000;
+
+    # Define an upstream pool to load-balance requests across the swisstopo tile servers
+    upstream wmts_servers {
+        server wmts1.geo.admin.ch:443;
+        server wmts2.geo.admin.ch:443;
+        server wmts3.geo.admin.ch:443;
+        server wmts4.geo.admin.ch:443;
+        server wmts5.geo.admin.ch:443;
+        server wmts6.geo.admin.ch:443;
+        server wmts7.geo.admin.ch:443;
+        server wmts9.geo.admin.ch:443;
+        server wmts10.geo.admin.ch:443;
+
+        # Keep upstream connections alive in a pool to reuse them
+        keepalive 64;
+    }
+
     server {
 
       # Disable gzipping of responses.
       gzip off;
 
       listen 80;
-      resolver 8.8.8.8 ipv6=off;
 
       location / {
 
@@ -32,8 +52,19 @@ http {
         proxy_cache_valid 200 302 301 1y;
 
         proxy_set_header        X-Forwarded-For $remote_addr;
-        proxy_pass              https://wmts.geo.admin.ch$uri$is_args$args;
+        
+        # Load balance requests to the upstream block
+        proxy_pass              https://wmts_servers;
+
+        # Set host header and SSL SNI name to wmts.geo.admin.ch
+        # so the SSL handshake and HTTP requests succeed
+        proxy_set_header        Host wmts.geo.admin.ch;
+        proxy_ssl_name          wmts.geo.admin.ch;
         proxy_ssl_server_name   on;
+
+        # Enable HTTP/1.1 and clear Connection header to support upstream keepalive
+        proxy_http_version      1.1;
+        proxy_set_header        Connection "";
 
       }
 


### PR DESCRIPTION
Backports the print URL fix and the tile cache reverse proxy load-balancing optimizations to the master branch.